### PR TITLE
import os

### DIFF
--- a/molecule_ec2/driver.py
+++ b/molecule_ec2/driver.py
@@ -19,6 +19,7 @@
 #  DEALINGS IN THE SOFTWARE.
 
 from base64 import b64decode
+import os
 import sys
 
 try:


### PR DESCRIPTION
`os.path` is used but there wasn't an `import os`, causing `molecule init scenario` to crash.

Resolves #3 