### PR TITLE
replaced python2 with python3

### DIFF
--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/prepare.yml
@@ -4,8 +4,9 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Install python for Ansible
-      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
+    - name: Make sure python3 is installed
+      package:
+        name: python3
+        state: present
       become: true
-      changed_when: false
 {%- endraw %}


### PR DESCRIPTION
We need to replace python2 installation by python3 installation in prepare.yaml for ec2 driver in molecule