### PR TITLE
Convert binary result to string - Fixes #13

### DIFF
--- a/molecule_ec2/driver.py
+++ b/molecule_ec2/driver.py
@@ -247,7 +247,7 @@ class EC2(Driver):
         decoded = b64decode(data_response["PasswordData"])
         with open(key_file, "rb") as f:
             key = load_pem_private_key(f.read(), None, default_backend())
-        return key.decrypt(decoded, PKCS1v15()).decode('utf-8')
+        return key.decrypt(decoded, PKCS1v15()).decode("utf-8")
 
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks

--- a/molecule_ec2/driver.py
+++ b/molecule_ec2/driver.py
@@ -247,7 +247,7 @@ class EC2(Driver):
         decoded = b64decode(data_response["PasswordData"])
         with open(key_file, "rb") as f:
             key = load_pem_private_key(f.read(), None, default_backend())
-        return key.decrypt(decoded, PKCS1v15())
+        return key.decrypt(decoded, PKCS1v15()).decode('utf-8')
 
     def sanity_checks(self):
         # FIXME(decentral1se): Implement sanity checks


### PR DESCRIPTION
Fixes #13

Tested and works on python3

Untested on python2. Will return a unicode string object.
Unable to determine how molecule translates those when generating
output.