### PR TITLE
Fix security group not in the correct VPC

### DIFF
--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -29,12 +29,20 @@
     keypair_name: molecule_key
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
-    - name: Create security group
+    - name: Find the vpc for the subnet
+      ec2_vpc_subnet_facts:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ molecule_yml.platforms }}"
+      register: subnet_facts
+
+    - name: Create security groups
       ec2_group:
+        vpc_id: "{{ item.subnets[0].vpc_id }}"
         name: "{{ security_group_name }}"
         description: "{{ security_group_name }}"
         rules: "{{ security_group_rules }}"
         rules_egress: "{{ security_group_rules_egress }}"
+      loop: "{{ subnet_facts.results }}"
 
     - name: Test for presence of local keypair
       stat:


### PR DESCRIPTION
Fix #5

Currently the `molecule` security group is created in the default VPC.

If we use a non-default VPC, for example:

```yml
# ...
platforms:
  - name: instance
    image_owner: 099xxx
    image_name: ubuntu/images/xxx
    instance_type: t2.micro
    vpc_subnet_id: subnet-035xxx
# ...
```

The instance creation will fail because the security group and the instance are in different VPCs:

```sh
"msg": "The following group names are not valid: molecule"
```

Same as https://github.com/ansible-community/molecule/pull/1644 (merged before we [move EC2 driver to its own repository](https://github.com/ansible-community/molecule/commit/beaba2099cc8b98c27d5bb722c9fccf61bd550e7))