### PR TITLE
Allow user to specify different ssh_user

### DIFF
--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -85,9 +85,9 @@
         instance_type: "{{ item.instance_type }}"
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
-        instance_tags: "{{ item.instance_tags | combine({'instance': item.name})
+        instance_tags: "{{ item.instance_tags | combine({'instance': item.name, 'ssh_user': item.ssh_user | default(ssh_user)})
           if item.instance_tags is defined
-          else {'instance': item.name} }}"
+          else {'instance': item.name, 'ssh_user': item.ssh_user | default(ssh_user)} }}"
         wait: true
         assign_public_ip: true
         exact_count: 1
@@ -115,7 +115,7 @@
         instance_conf_dict: {
           'instance': "{{ item.instances[0].tags.instance }}",
           'address': "{{ item.instances[0].public_ip }}",
-          'user': "{{ ssh_user }}",
+          'user': "{{ item.instances[0].tags.ssh_user }}",
           'port': "{{ ssh_port }}",
           'identity_file': "{{ keypair_path }}",
           'instance_ids': "{{ item.instance_ids }}", }

--- a/molecule_ec2/test/scenarios/driver/ec2/molecule/default/molecule.yml
+++ b/molecule_ec2/test/scenarios/driver/ec2/molecule/default/molecule.yml
@@ -12,6 +12,7 @@ platforms:
     image: ami-a5b196c0
     instance_type: t2.micro
     vpc_subnet_id: subnet-6456fd1f
+    ssh_user: ubuntu
 provisioner:
   name: ansible
   config_options:

--- a/molecule_ec2/test/scenarios/driver/ec2/molecule/multi-node/molecule.yml
+++ b/molecule_ec2/test/scenarios/driver/ec2/molecule/multi-node/molecule.yml
@@ -12,6 +12,7 @@ platforms:
     image: ami-a5b196c0
     instance_type: t2.micro
     vpc_subnet_id: subnet-6456fd1f
+    ssh_user: ubuntu
     groups:
       - foo
       - bar
@@ -19,6 +20,7 @@ platforms:
     image: ami-a5b196c0
     instance_type: t2.micro
     vpc_subnet_id: subnet-6456fd1f
+    ssh_user: ubuntu
     groups:
       - foo
       - baz


### PR DESCRIPTION
Currently, the template only supports Ubuntu because `ssh_user` is hardcoded to `ubuntu`. If we use a different distro, Debian for example:

```yml
# ...
  - name: debian9
    image_owner: 679xxx
    image_name: debian-stretch-*
    instance_type: t2.micro
    vpc_subnet_id: subnet-035xxx
    instance_tags:
      Name: molecule-test-debian9
# ...
```

The test will fail because Debian doesn't have the `ubuntu` user:

```
fatal: [debian9]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: load pubkey \"/home/user/.cache/molecule/my-role/ec2/ssh_key\": invalid format\r\nubuntu@35.178.xxx.xx: Permission denied (publickey).", "unreachable": true}
```

We need to use the `admin` user instead. This merge request will add an optional `ssh_user` variable, for example:

```yml
# ...
  - name: debian9
    image_owner: 679xxx
    image_name: debian-stretch-*
    instance_type: t2.micro
    vpc_subnet_id: subnet-035xxx
    ssh_user: admin
    instance_tags:
      Name: molecule-test-debian9
# ...
```

Because this is optional so it will not break current users' code. If no `ssh_user` specified the default value `ubuntu` will be used.

Idea from https://github.com/ansible-community/molecule/pull/2230