### PR TITLE
Fix #23 - allow parallel execution

### DIFF
--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -14,7 +14,7 @@
     # Create abbreviated versions to keep name lengths sane
     rut: "{{ role_under_test | regex_replace('\\b(\\w).*?(?=\\b)', '\\1') | regex_replace('\\W') }}"
     scnr: "{{ scenario | regex_replace('\\b(\\w).*?(?=\\b)', '\\1') | regex_replace('\\W') }}"
-    test_identifier: "{{ rut }}-{{ scnr }}"
+    test_identifier: "{{ lookup('env', 'EC2_TEST_IDENTIFIER') | default(rut ~ '-' ~ scnr, true) }}"
 
     security_group_name: "{{ test_identifier }}-molecule"
     security_group_description: Security group for testing Molecule

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -9,7 +9,14 @@
     ssh_user: ubuntu
     ssh_port: 22
 
-    security_group_name: molecule
+    role_under_test: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY').split('/')[-1] }}"
+    scenario: "{{ lookup('env', 'MOLECULE_SCENARIO_NAME') }}"
+    # Create abbreviated versions to keep name lengths sane
+    rut: "{{ role_under_test | regex_replace('\\b(\\w).*?(?=\\b)', '\\1') | regex_replace('\\W') }}"
+    scnr: "{{ scenario | regex_replace('\\b(\\w).*?(?=\\b)', '\\1') | regex_replace('\\W') }}"
+    test_identifier: "{{ rut }}-{{ scnr }}"
+
+    security_group_name: "{{ test_identifier }}-molecule"
     security_group_description: Security group for testing Molecule
     security_group_rules:
       - proto: tcp
@@ -26,7 +33,7 @@
         to_port: 0
         cidr_ip: '0.0.0.0/0'
 
-    keypair_name: molecule_key
+    keypair_name: "{{ test_identifier }}-key"
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
   tasks:
     - name: Find the vpc for the subnet
@@ -85,14 +92,14 @@
         instance_type: "{{ item.instance_type }}"
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
-        instance_tags: "{{ item.instance_tags | combine({'instance': item.name})
+        instance_tags: "{{ item.instance_tags | combine({'instance': item.name, 'Name': test_identifier ~ '-' ~ item.name})
           if item.instance_tags is defined
-          else {'instance': item.name} }}"
+          else {'instance': item.name, 'Name': test_identifier ~ '-' ~ item.name, 'Test': role_under_test, 'Scenario': scenario} }}"
         wait: true
         assign_public_ip: true
         exact_count: 1
         count_tag:
-          instance: "{{ item.name }}"
+          Name: "{{ test_identifier ~ '-' ~ item.name }}"
       register: server
       loop: "{{ molecule_yml.platforms }}"
       loop_control:


### PR DESCRIPTION
This patch prepends a string based on the role and scenario being tested to the front of the AWS element names.

This allows multiple roles to be tested at the same time. It also allows each scenario for a role to be run in parallel.

These features fix ansible-community/molecule-plugins#49 

The optional environment variable override is designed to allow parallel functional testing by ansible-community/molecule-ec2#21

Adding the scenario element does reverse the changes made by https://github.com/ansible-community/molecule/issues/895
However I believe that the AWS requirements are unique due to the single namespace.