### PR TITLE
Rename deprecated ansible filters

### DIFF
--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -130,7 +130,7 @@
 
     - name: Dump instance config
       copy:
-        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        content: "{{ instance_conf | to_json | from_json | to_yaml | header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool
 
@@ -141,7 +141,7 @@
         search_regex: SSH
         delay: 10
         timeout: 320
-      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
 
     - name: Wait for boot process to finish
       pause:

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -9,7 +9,7 @@
     - block:
         - name: Populate instance config
           set_fact:
-            instance_conf: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+            instance_conf: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
             skip_instances: false
       rescue:
         - name: Populate instance config when file missing
@@ -43,7 +43,7 @@
 
     - name: Dump instance config
       copy:
-        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        content: "{{ instance_conf | to_json | from_json | to_yaml | header }}"
         dest: "{{ molecule_instance_config }}"
       when: server.changed | bool
 {%- endraw %}


### PR DESCRIPTION
Hello, thank you for providing this tool. I find it immensely useful.
Lately I have had some struggles in making the latest molecule-ec2 version to work, therefore I'd like to contribute with something that helped me getting through.

The new Molecule Ansible filters changed their name (e.g. "molecule_to_yaml" to "to_yaml") therefore Molecule's create and destroy steps, using the EC2 driver, break. I have changed the name of these filters in the create.yml and destroy.yml templates, according to https://github.com/ansible-collections/community.molecule/blob/main/plugins/filter/molecule_core.py,  and tests pass in my local development environment.

My local python environment specs:

```
$ python --version
Python 3.9.0

$ pip3 freeze
appdirs==1.4.4
certifi==2020.6.20
distlib==0.3.1
filelock==3.0.12
packaging==20.4
pluggy==0.13.1
py==1.9.0
pyparsing==2.4.7
six==1.15.0
toml==0.10.2
tox==3.20.1
virtualenv==20.1.0
```

The tox tests that I have performed pass:

```
$ tox -e lint,py39,py39-devel
========================================================================================= short test summary info ==========================================================================================
XFAIL molecule_ec2/test/functional/test_ec2.py::test_command_init_scenario
  need to fix template path
======================================================================================= 1 passed, 1 xfailed in 0.35s =======================================================================================
py39-devel finish: run-test  after 1.74 seconds
py39-devel start: run-test-post 
py39-devel finish: run-test-post  after 0.00 seconds
_________________________________________________________________________________________________ summary __________________________________________________________________________________________________
  lint: commands succeeded
  py39: commands succeeded
  py39-devel: commands succeeded
  congratulations :)

```