### PR TITLE
Add RDP login support for windows hosts

### DIFF
--- a/molecule_ec2/driver.py
+++ b/molecule_ec2/driver.py
@@ -169,15 +169,38 @@ class EC2(Driver):
 
     @property
     def login_cmd_template(self):
-        connection_options = " ".join(self.ssh_connection_options)
+        if self._config.command_args.get('host'):
+            hostname = self._config.command_args['host']
+        elif len(self._config.platforms.instances) == 1:
+            hostname = self._config.platforms.instances[0]['name']
+        else:
+            LOG.error("Please specify instance via '--host'")
+            sys.exit(1)
+        
+        ansible_connection_options = self.ansible_connection_options(hostname)
+        if ansible_connection_options.get('ansible_connection') == 'winrm':
+            return (
+                "xfreerdp "
+                "\"/u:%s\" "
+                "\"/p:%s\" "
+                "/v:%s "
+                "/cert-tofu "
+                "+clipboard "
+                "/grab-keyboard" % (ansible_connection_options['ansible_user'],
+                                    ansible_connection_options['ansible_password'],
+                                    ansible_connection_options['ansible_host'])
+            )
 
-        return (
-            "ssh {{address}} "
-            "-l {{user}} "
-            "-p {{port}} "
-            "-i {{identity_file}} "
-            "{}"
-        ).format(connection_options)
+        else:  # normal ssh connection
+            connection_options = " ".join(self.ssh_connection_options)
+
+            return (
+                "ssh {{address}} "
+                "-l {{user}} "
+                "-p {{port}} "
+                "-i {{identity_file}} "
+                "{}"
+            ).format(connection_options)
 
     @property
     def default_safe_files(self):

--- a/molecule_ec2/driver.py
+++ b/molecule_ec2/driver.py
@@ -169,26 +169,29 @@ class EC2(Driver):
 
     @property
     def login_cmd_template(self):
-        if self._config.command_args.get('host'):
-            hostname = self._config.command_args['host']
+        if self._config.command_args.get("host"):
+            hostname = self._config.command_args["host"]
         elif len(self._config.platforms.instances) == 1:
-            hostname = self._config.platforms.instances[0]['name']
+            hostname = self._config.platforms.instances[0]["name"]
         else:
             LOG.error("Please specify instance via '--host'")
             sys.exit(1)
-        
+
         ansible_connection_options = self.ansible_connection_options(hostname)
-        if ansible_connection_options.get('ansible_connection') == 'winrm':
+        if ansible_connection_options.get("ansible_connection") == "winrm":
             return (
                 "xfreerdp "
-                "\"/u:%s\" "
-                "\"/p:%s\" "
+                '"/u:%s" '
+                '"/p:%s" '
                 "/v:%s "
                 "/cert-tofu "
                 "+clipboard "
-                "/grab-keyboard" % (ansible_connection_options['ansible_user'],
-                                    ansible_connection_options['ansible_password'],
-                                    ansible_connection_options['ansible_host'])
+                "/grab-keyboard"
+                % (
+                    ansible_connection_options["ansible_user"],
+                    ansible_connection_options["ansible_password"],
+                    ansible_connection_options["ansible_host"],
+                )
             )
 
         else:  # normal ssh connection


### PR DESCRIPTION
Current login command is hardcoded to SSH for all hosts. This enhancement adds a check for WinRM use, and for those hosts uses xfreerdp to open an RDP session instead.