### PR TITLE
Start using community.aws.ec2 collection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
 minimum_pre_commit_version: "1.14.0"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -29,7 +29,7 @@ repos:
         additional_dependencies:
           - flake8-black
   - repo: https://github.com/codespell-project/codespell.git
-    rev: v1.17.1
+    rev: v2.0.0
     hooks:
       - id: codespell
         name: codespell
@@ -41,7 +41,7 @@ repos:
         require_serial: false
         additional_dependencies: []
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.25.0
+    rev: v1.26.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,9 @@ With a new role
 This will create a new folder *my-role* containing a bare-bone generated
 role like you would do with ``ansible-galaxy init`` command.
 It will also contain a molecule folder with a default scenario
-using the ec2 driver (using ansible community.aws.ec2_instance collection). Install
-the collection using `ansible-galaxy install -r test_requirements.yml`.
+using the ec2 driver (using ansible community.aws.ec2_instance collection).
+Install the collection using
+`ansible-galaxy install -r test_requirements.yml`.
 
 In a pre-existing role
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ With a new role
 This will create a new folder *my-role* containing a bare-bone generated
 role like you would do with ``ansible-galaxy init`` command.
 It will also contain a molecule folder with a default scenario
-using the ec2 driver
+using the ec2 driver (using ansible community.aws.ec2_instance collection). Install
+the collection using `ansible-galaxy install -r test_requirements.yml`.
 
 In a pre-existing role
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -77,22 +77,20 @@
       register: ami_info
 
     - name: Create molecule instance(s)
-      ec2:
+      community.aws.ec2_instance:
         key_name: "{{ key_pair_name }}"
-        image: "{{ item.image
+        image_id: "{{ item.image
           if item.image is defined
           else (ami_info.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
         instance_type: "{{ item.instance_type }}"
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
-        group: "{{ security_group_name }}"
-        instance_tags: "{{ item.instance_tags | combine({'instance': item.name})
-          if item.instance_tags is defined
+        security_group: "{{ security_group_name }}"
+        tags: "{{ item.tags | combine({'instance': item.name})
+          if item.tags is defined
           else {'instance': item.name} }}"
         wait: true
-        assign_public_ip: true
-        exact_count: 1
-        count_tag:
-          instance: "{{ item.name }}"
+        network:
+          assign_public_ip: true
       register: server
       loop: "{{ molecule_yml.platforms }}"
       loop_control:

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -1,5 +1,8 @@
 ---
 {% raw -%}
+collections:
+  - name: community.aws
+
 - name: Create
   hosts: localhost
   connection: local
@@ -77,7 +80,7 @@
       register: ami_info
 
     - name: Create molecule instance(s)
-      community.aws.ec2_instance:
+      ec2_instance:
         key_name: "{{ key_pair_name }}"
         image_id: "{{ item.image
           if item.image is defined

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -18,7 +18,7 @@
             skip_instances: true
 
     - name: Destroy molecule instance(s)
-      ec2:
+      community.aws.ec2_instance:
         state: absent
         instance_ids: "{{ item.instance_ids }}"
       register: server

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -1,5 +1,8 @@
 ---
 {% raw -%}
+collections:
+  - name: community.aws
+
 - name: Destroy
   hosts: localhost
   connection: local
@@ -18,7 +21,7 @@
             skip_instances: true
 
     - name: Destroy molecule instance(s)
-      community.aws.ec2_instance:
+      ec2_instance:
         state: absent
         instance_ids: "{{ item.instance_ids }}"
       register: server

--- a/test_requirements.yml
+++ b/test_requirements.yml
@@ -1,0 +1,4 @@
+---
+roles: []
+collections:
+  - community.aws


### PR DESCRIPTION
transition to collection community.aws.ec2 as this uses boto3 and ec2 is only maintained but doesn't get any new features. EC2 also depends on boto only which is sort of deprecated.

Signed-off-by: tbugfinder