### PR TITLE
Enhanced instance customizations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ This is a molecule.yml example file
        image_name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*
        instance_type: t2.micro
        vpc_subnet_id: <your-aws-vpc-subnet-id>
-       instance_tags:
+       tags:
          - Name: molecule_instance
    provisioner:
      name: ansible

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -1,150 +1,315 @@
 ---
 {% raw -%}
-collections:
-  - name: community.aws
-
 - name: Create
   hosts: localhost
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.aws
+    - community.crypto
   vars:
-    ssh_user: ubuntu
-    ssh_port: 22
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
 
-    security_group_name: molecule
-    security_group_description: Security group for testing Molecule
-    security_group_rules:
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: '{{ default_run_config | combine(run_config_from_file) }}'
+
+    # Platform settings handling
+    default_assign_public_ip: true
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_boot_wait_seconds: 120
+    default_instance_type: t3a.medium
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: molecule_key
+    default_private_key_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/id_rsa"
+    default_public_key_path: "{{ default_private_key_path }}.pub"
+    default_region: "{{ lookup('env', 'DEFAULT_REGION') }}"
+    default_ssh_user: ubuntu
+    default_ssh_port: 22
+    default_user_data: ''
+
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_description: Ephemeral security group for Molecule instances
+    default_security_group_rules:
       - proto: tcp
-        from_port: "{{ ssh_port }}"
-        to_port: "{{ ssh_port }}"
-        cidr_ip: '0.0.0.0/0'
+        from_port: "{{ default_ssh_port }}"
+        to_port: "{{ default_ssh_port }}"
+        cidr_ip: "0.0.0.0/0"
       - proto: icmp
         from_port: 8
         to_port: -1
-        cidr_ip: '0.0.0.0/0'
-    security_group_rules_egress:
+        cidr_ip: "0.0.0.0/0"
+    default_security_group_rules_egress:
       - proto: -1
         from_port: 0
         to_port: 0
-        cidr_ip: '0.0.0.0/0'
+        cidr_ip: "0.0.0.0/0"
 
-    key_pair_name: molecule_key
-    key_pair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+    platform_defaults:
+      assign_public_ip: "{{ default_assign_public_ip }}"
+      boot_wait_seconds: "{{ default_boot_wait_seconds }}"
+      instance_type: "{{ default_instance_type }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      private_key_path: "{{ default_private_key_path }}"
+      public_key_path: "{{ default_public_key_path }}"
+      region: "{{ default_region }}"
+      security_group_name: "{{ default_security_group_name }}"
+      security_group_description: "{{ default_security_group_description }}"
+      security_group_rules: "{{ default_security_group_rules }}"
+      security_group_rules_egress: "{{ default_security_group_rules_egress }}"
+      ssh_user: "{{ default_ssh_user }}"
+      ssh_port: "{{ default_ssh_port }}"
+      cloud_config: {}
+      image: ""
+      image_name: ""
+      image_owner: [self]
+      name: ""
+      security_groups: []
+      tags: {}
+      volumes: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging a list of dicts into defaults is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+  pre_tasks:
+    - name: Validate platform configurations
+      assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.assign_public_ip is boolean
+          - platform.boot_wait_seconds is integer and platform.boot_wait_seconds >= 0
+          - platform.cloud_config is mapping
+          - platform.image is string
+          - platform.image_name is string
+          - platform.image_owner is sequence or (platform.image_owner is string and platform.image_owner | length > 0)
+          - platform.instance_type is string and platform.instance_type | length > 0
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.private_key_path is string and platform.private_key_path | length > 0
+          - platform.public_key_path is string and platform.public_key_path | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_group_description is string and platform.security_group_description | length > 0
+          - platform.security_group_rules is sequence
+          - platform.security_group_rules_egress is sequence
+          - platform.security_groups is sequence
+          - platform.ssh_user is string and platform.ssh_user | length > 0
+          - platform.ssh_port is integer and platform.ssh_port in range(1, 65536)
+          - platform.security_groups is sequence
+          - platform.tags is mapping
+          - platform.volumes is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: '{{ platforms }}'
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
   tasks:
-    - name: Find the vpc for the subnet
-      ec2_vpc_subnet_info:
-        subnet_ids: "{{ item.vpc_subnet_id }}"
-      loop: "{{ molecule_yml.platforms }}"
-      register: subnet_info
-
-    - name: Create security groups
-      ec2_group:
-        vpc_id: "{{ item.subnets[0].vpc_id }}"
-        name: "{{ security_group_name }}"
-        description: "{{ security_group_name }}"
-        rules: "{{ security_group_rules }}"
-        rules_egress: "{{ security_group_rules_egress }}"
-      loop: "{{ subnet_info.results }}"
-
-    - name: Test for presence of local key pair
-      stat:
-        path: "{{ key_pair_path }}"
-      register: key_pair_local
-
-    - name: Delete remote key pair
-      ec2_key:
-        name: "{{ key_pair_name }}"
-        state: absent
-      when: not key_pair_local.stat.exists
-
-    - name: Create key pair
-      ec2_key:
-        name: "{{ key_pair_name }}"
-      register: key_pair
-
-    - name: Persist the key pair
+    - name: Write run config to file
       copy:
-        dest: "{{ key_pair_path }}"
-        content: "{{ key_pair.key.private_key }}"
-        mode: 0600
-      when: key_pair.changed
+        dest: "{{ run_config_path }}"
+        content: "{{ run_config | to_yaml }}"
 
-    - name: Get the ec2 ami(s) by owner and name, if image not set
+    - name: Generate local key pairs
+      openssh_keypair:
+        path: "{{ item.private_key_path }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: local_keypairs
+
+    - name: Look up EC2 AMI(s) by owner and name (if image not set)
       ec2_ami_info:
         owners: "{{ item.image_owner }}"
         filters:
           name: "{{ item.image_name }}"
-      loop: "{{ molecule_yml.platforms }}"
-      when: item.image is not defined
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.image
       register: ami_info
 
-    - name: Create molecule instance(s)
-      ec2_instance:
-        key_name: "{{ key_pair_name }}"
-        image_id: "{{ item.image
-          if item.image is defined
-          else (ami_info.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
-        instance_type: "{{ item.instance_type }}"
-        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
-        security_group: "{{ security_group_name }}"
-        tags: "{{ item.tags | combine({'instance': item.name})
-          if item.tags is defined
-          else {'instance': item.name} }}"
-        wait: true
-        network:
-          assign_public_ip: true
-      register: server
-      loop: "{{ molecule_yml.platforms }}"
+    - name: Look up subnets to determine VPCs (if needed)
+      ec2_vpc_subnet_info:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      assert:
+        that:
+          - platform.image or (ami_info.results[index].images | length > 0)
+          - platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Create ephemeral EC2 key pairs (if needed)
+      ec2_key:
+        name: "{{ item.key_name }}"
+        key_material: "{{ key_pair.public_key }}"
+      vars:
+        key_pair: "{{ local_key_pairs.results[index] }}"
+      loop: "{{ platforms }}"
       loop_control:
         index_var: index
+        label: "{{ item.name }}"
+      when: item.key_inject_method == "ec2"
+      register: ec2_keys
+
+    - name: Create ephemeral security groups (if needed)
+      ec2_group:
+        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+        name: "{{ item.security_group_name }}"
+        description: "{{ item.security_group_description }}"
+        rules: "{{ item.security_group_rules }}"
+        rules_egress: "{{ item.security_group_rules_egress }}"
+      vars:
+        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.security_groups | length == 0
+
+    #- fail:
+    #    msg: "{{ platforms[0].key_name }}"
+
+    - name: Create ephemeral EC2 instance(s)
+      ec2_instance:
+        region: "{{ item.region }}"
+        filters: "{{ platform_filters }}"
+        instance_type: "{{ item.instance_type }}"
+        image_id: "{{ platform_image_id }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        security_groups: "{{ platform_security_groups }}"
+        network:
+          assign_public_ip: "{{ item.assign_public_ip }}"
+        volumes: "{{ item.volumes }}"
+        key_name: "{{ (item.key_inject_method == 'ec2') | ternary(item.key_name, omit) }}"
+        tags: "{{ platform_tags }}"
+        user_data: "{{ platform_user_data }}"
+        wait: true
+      vars:
+        platform_security_groups: "{{ item.security_groups or [item.security_group_name] }}"
+        platform_generated_image_id: "{{ (ami_info.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
+        platform_image_id: "{{ item.image or platform_generated_image_id }}"
+
+        platform_generated_cloud_config:
+          users:
+            - name: "{{ item.ssh_user }}"
+              ssh_authorized_keys:
+                - "{{ local_keypairs.results[index].public_key }}"
+              sudo: "ALL=(ALL) NOPASSWD:ALL"
+        platform_cloud_config: >-
+          {{ (item.key_inject_method == 'cloud-init')
+               | ternary((item.cloud_config | combine(platform_generated_cloud_config)), item.cloud_config) }}
+        platform_user_data: |-
+          #cloud-config
+          {{ platform_cloud_config | to_yaml }}
+
+        platform_generated_tags:
+          instance: "{{ item.name }}"
+          "molecule-run-id": "{{ run_config.run_id }}"
+        platform_tags: "{{ (item.tags or {}) | combine(platform_generated_tags) }}"
+        platform_filter_keys: "{{ platform_generated_tags.keys() | map('regex_replace', '^(.+)$', 'tag:\\1') }}"
+        platform_filters: "{{ dict(platform_filter_keys | zip(platform_generated_tags.values())) }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      register: ec2_instances_async
       async: 7200
       poll: 0
 
-    - name: Wait for instance(s) creation to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      register: ec2_jobs
-      until: ec2_jobs.finished
-      retries: 300
-      with_items: "{{ server.results }}"
+    - block:
+        - name: Wait for instance(s) creation to complete
+          async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
 
-    # Mandatory configuration for Molecule to function.
+        - name: Collect instance configs
+          set_fact:
+            instance_config:
+              instance: "{{ item.name }}"
+              address: "{{ item.assign_public_ip | ternary(instance.public_ip_address, instance.private_ip_address) }}"
+              user: "{{ item.ssh_user }}"
+              port: "{{ item.ssh_port }}"
+              identity_file: "{{ item.private_key_path }}"
+              instance_ids:
+                - "{{ instance.instance_id }}"
+          vars:
+            instance: "{{ ec2_instances.results[index].instances[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          register: instance_configs
 
-    - name: Populate instance config dict
-      set_fact:
-        instance_conf_dict: {
-          'instance': "{{ item.instances[0].tags.instance }}",
-          'address': "{{ item.instances[0].public_ip }}",
-          'user': "{{ ssh_user }}",
-          'port': "{{ ssh_port }}",
-          'identity_file': "{{ key_pair_path }}",
-          'instance_ids': "{{ item.instance_ids }}", }
-      with_items: "{{ ec2_jobs.results }}"
-      register: instance_config_dict
-      when: server.changed | bool
+        - name: Write Molecule instance configs
+          copy:
+            dest: "{{ molecule_instance_config }}"
+            content: >-
+              {{ instance_configs.results
+                   | map(attribute='ansible_facts.instance_config')
+                   | list
+                   | to_json
+                   | from_json
+                   | to_yaml }}
 
-    - name: Convert instance config dict to a list
-      set_fact:
-        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
-      when: server.changed | bool
+        - name: Start SSH pollers
+          wait_for:
+            host: "{{ item.address }}"
+            port: "{{ item.port }}"
+            search_regex: SSH
+            delay: 10
+            timeout: 320
+          loop: "{{ instance_configs.results | map(attribute='ansible_facts.instance_config') | list }}"
+          loop_control:
+            label: "{{ item.instance }}"
+          register: ssh_wait_async
+          async: 300
+          poll: 0
 
-    - name: Dump instance config
-      copy:
-        content: "{{ instance_conf | to_json | from_json | to_yaml }}"
-        dest: "{{ molecule_instance_config }}"
-      when: server.changed | bool
+        - name: Wait for SSH
+          async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ssh_wait_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          until: ssh_wait_async is finished
+          retries: 300
+          delay: 1
 
-    - name: Wait for SSH
-      wait_for:
-        port: "{{ ssh_port }}"
-        host: "{{ item.address }}"
-        search_regex: SSH
-        delay: 10
-        timeout: 320
-      with_items: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
-
-    - name: Wait for boot process to finish
-      pause:
-        minutes: 2
+        - name: Wait for boot process to finish
+          pause:
+            seconds: "{{ platforms | map(attribute='boot_wait_seconds') | max }}"
+      when: ec2_instances_async is changed
 {%- endraw %}

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -1,5 +1,5 @@
----
 {% raw -%}
+---
 - name: Create
   hosts: localhost
   connection: local
@@ -24,10 +24,9 @@
     default_boot_wait_seconds: 120
     default_instance_type: t3a.medium
     default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
-    default_key_name: molecule_key
+    default_key_name: "molecule-{{ run_config.run_id }}"
     default_private_key_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/id_rsa"
     default_public_key_path: "{{ default_private_key_path }}.pub"
-    default_region: "{{ lookup('env', 'DEFAULT_REGION') }}"
     default_ssh_user: ubuntu
     default_ssh_port: 22
     default_user_data: ''
@@ -51,13 +50,13 @@
 
     platform_defaults:
       assign_public_ip: "{{ default_assign_public_ip }}"
+      aws_profile: "{{ default_aws_profile }}"
       boot_wait_seconds: "{{ default_boot_wait_seconds }}"
       instance_type: "{{ default_instance_type }}"
       key_inject_method: "{{ default_key_inject_method }}"
       key_name: "{{ default_key_name }}"
       private_key_path: "{{ default_private_key_path }}"
       public_key_path: "{{ default_public_key_path }}"
-      region: "{{ default_region }}"
       security_group_name: "{{ default_security_group_name }}"
       security_group_description: "{{ default_security_group_description }}"
       security_group_rules: "{{ default_security_group_rules }}"
@@ -69,13 +68,14 @@
       image_name: ""
       image_owner: [self]
       name: ""
+      region: ""
       security_groups: []
       tags: {}
       volumes: []
       vpc_id: ""
       vpc_subnet_id: ""
 
-    # Merging a list of dicts into defaults is, it turns out, not straightforward
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
     platforms: >-
       {{ [platform_defaults | dict2items]
            | product(molecule_yml.platforms | map('dict2items') | list)
@@ -90,6 +90,7 @@
           - platforms | length > 0
           - platform.name is string and platform.name | length > 0
           - platform.assign_public_ip is boolean
+          - platform.aws_profile is string
           - platform.boot_wait_seconds is integer and platform.boot_wait_seconds >= 0
           - platform.cloud_config is mapping
           - platform.image is string
@@ -108,7 +109,6 @@
           - platform.security_groups is sequence
           - platform.ssh_user is string and platform.ssh_user | length > 0
           - platform.ssh_port is integer and platform.ssh_port in range(1, 65536)
-          - platform.security_groups is sequence
           - platform.tags is mapping
           - platform.volumes is sequence
           - platform.vpc_id is string
@@ -127,6 +127,9 @@
     - name: Generate local key pairs
       openssh_keypair:
         path: "{{ item.private_key_path }}"
+        type: rsa
+        size: 2048
+        regenerate: never
       loop: "{{ platforms }}"
       loop_control:
         label: "{{ item.name }}"
@@ -154,7 +157,7 @@
 
     - name: Validate discovered information
       assert:
-        that:
+        that: 
           - platform.image or (ami_info.results[index].images | length > 0)
           - platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
         quiet: true
@@ -164,12 +167,14 @@
         index_var: index
         label: "{{ platform.name }}"
 
-    - name: Create ephemeral EC2 key pairs (if needed)
+    - name: Create ephemeral EC2 keys (if needed)
       ec2_key:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
         name: "{{ item.key_name }}"
-        key_material: "{{ key_pair.public_key }}"
+        key_material: "{{ keypair.public_key }}"
       vars:
-        key_pair: "{{ local_key_pairs.results[index] }}"
+        keypair: "{{ local_keypairs.results[index] }}"
       loop: "{{ platforms }}"
       loop_control:
         index_var: index
@@ -179,6 +184,8 @@
 
     - name: Create ephemeral security groups (if needed)
       ec2_group:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
         vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
         name: "{{ item.security_group_name }}"
         description: "{{ item.security_group_description }}"
@@ -192,12 +199,10 @@
         label: "{{ item.name }}"
       when: item.security_groups | length == 0
 
-    #- fail:
-    #    msg: "{{ platforms[0].key_name }}"
-
     - name: Create ephemeral EC2 instance(s)
       ec2_instance:
-        region: "{{ item.region }}"
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
         filters: "{{ platform_filters }}"
         instance_type: "{{ item.instance_type }}"
         image_id: "{{ platform_image_id }}"
@@ -243,7 +248,7 @@
       poll: 0
 
     - block:
-        - name: Wait for instance(s) creation to complete
+        - name: Wait for instance creation to complete
           async_status:
             jid: "{{ item.ansible_job_id }}"
           loop: "{{ ec2_instances_async.results }}"
@@ -253,7 +258,7 @@
           register: ec2_instances
           until: ec2_instances is finished
           retries: 300
-
+      
         - name: Collect instance configs
           set_fact:
             instance_config:
@@ -304,10 +309,11 @@
           loop_control:
             index_var: index
             label: "{{ platforms[index].name }}"
+          register: ssh_wait
           until: ssh_wait_async is finished
           retries: 300
           delay: 1
-
+      
         - name: Wait for boot process to finish
           pause:
             seconds: "{{ platforms | map(attribute='boot_wait_seconds') | max }}"

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -157,7 +157,7 @@
 
     - name: Validate discovered information
       assert:
-        that: 
+        that:
           - platform.image or (ami_info.results[index].images | length > 0)
           - platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
         quiet: true
@@ -172,9 +172,9 @@
         profile: "{{ item.aws_profile | default(omit) }}"
         region: "{{ item.region | default(omit) }}"
         name: "{{ item.key_name }}"
-        key_material: "{{ keypair.public_key }}"
+        key_material: "{{ local_keypair.public_key }}"
       vars:
-        keypair: "{{ local_keypairs.results[index] }}"
+        local_keypair: "{{ local_keypairs.results[index] }}"
       loop: "{{ platforms }}"
       loop_control:
         index_var: index
@@ -258,7 +258,7 @@
           register: ec2_instances
           until: ec2_instances is finished
           retries: 300
-      
+
         - name: Collect instance configs
           set_fact:
             instance_config:
@@ -313,7 +313,7 @@
           until: ssh_wait_async is finished
           retries: 300
           delay: 1
-      
+
         - name: Wait for boot process to finish
           pause:
             seconds: "{{ platforms | map(attribute='boot_wait_seconds') | max }}"

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -1,4 +1,3 @@
----
 {% raw -%}
 ---
 - name: Destroy
@@ -9,17 +8,134 @@
   collections:
     - community.aws
   vars:
-    instance_configs: "{{ (lookup('file', molecule_instance_config, errors='ignore') or '{}') | from_yaml }}"
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: '{{ default_run_config | combine(run_config_from_file) }}'
+
+    # Platform settings handling
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+
+    platform_defaults:
+      aws_profile: "{{ default_aws_profile }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      region: ""
+      security_group_name: "{{ default_security_group_name }}"
+      security_groups: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+
+    # Stored instance config
+    instance_config: "{{ (lookup('file', molecule_instance_config, errors='ignore') or '{}') | from_yaml }}"
+  pre_tasks:
+    - name: Validate platform configurations
+      assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.aws_profile is string
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_groups is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: '{{ platforms }}'
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
   tasks:
-    - name: Destroy ephemeral EC2 instance(s)
+    - name: Look up subnets to determine VPCs (if needed)
+      ec2_vpc_subnet_info:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      assert:
+        that: platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Destroy ephemeral EC2 instances
       ec2_instance:
-        instance_ids: "{{ instance_configs | map(attribute='instance_ids') | flatten }}"
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
         state: absent
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: ec2_instances_async
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance destruction to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      loop: "{{ ec2_instances_async.results }}"
+      loop_control:
+        index_var: index
+        label: "{{ platforms[index].name }}"
+      register: ec2_instances
+      until: ec2_instances is finished
+      retries: 300
 
     - name: Write Molecule instance configs
       copy:
         dest: "{{ molecule_instance_config }}"
-        content: |
-          ---
-          []
+        content: "{{ {} | to_yaml }}"
+
+    - name: Destroy ephemeral security groups (if needed)
+      ec2_group:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+        name: "{{ item.security_group_name }}"
+        state: absent
+      vars:
+        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.security_groups | length == 0
+
+    - name: Destroy ephemeral keys (if needed)
+      ec2_key:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        name: "{{ item.key_name }}"
+        state: absent
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.key_inject_method == "ec2"
 {%- endraw %}

--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -1,52 +1,25 @@
 ---
 {% raw -%}
-collections:
-  - name: community.aws
-
+---
 - name: Destroy
   hosts: localhost
   connection: local
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
+  collections:
+    - community.aws
+  vars:
+    instance_configs: "{{ (lookup('file', molecule_instance_config, errors='ignore') or '{}') | from_yaml }}"
   tasks:
-    - block:
-        - name: Populate instance config
-          set_fact:
-            instance_conf: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
-            skip_instances: false
-      rescue:
-        - name: Populate instance config when file missing
-          set_fact:
-            instance_conf: {}
-            skip_instances: true
-
-    - name: Destroy molecule instance(s)
+    - name: Destroy ephemeral EC2 instance(s)
       ec2_instance:
+        instance_ids: "{{ instance_configs | map(attribute='instance_ids') | flatten }}"
         state: absent
-        instance_ids: "{{ item.instance_ids }}"
-      register: server
-      with_items: "{{ instance_conf }}"
-      when: not skip_instances
-      async: 7200
-      poll: 0
 
-    - name: Wait for instance(s) deletion to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      register: ec2_jobs
-      until: ec2_jobs.finished
-      retries: 300
-      with_items: "{{ server.results }}"
-
-    # Mandatory configuration for Molecule to function.
-
-    - name: Populate instance config
-      set_fact:
-        instance_conf: {}
-
-    - name: Dump instance config
+    - name: Write Molecule instance configs
       copy:
-        content: "{{ instance_conf | to_json | from_json | to_yaml }}"
         dest: "{{ molecule_instance_config }}"
-      when: server.changed | bool
+        content: |
+          ---
+          []
 {%- endraw %}


### PR DESCRIPTION
This is a large patch, constituting essentially a complete rewrite of the `create.yml` playbook. This change preserves backwards compatibility with existing `molecule.yml` platform definitions, but adds many significant new features:

* In some environments with constrained IAM permissions, users may have permission to launch instances, but not to create new security groups or key pairs. Key pairs can now be injected via instance user-data, and the instance can use existing security groups with the `security_groups` .
* Unique run identifiers are generated, tracked, and tagged on instances to tie them to a specific molecule-ec2 run.
* When generating security groups and keys, the run identifier is now appended. This helps prevent collisions when several people or CI jobs are running Molecule jobs concurrently.
* Parameters are validated by assertions, generating useful error messages when something is mis-specified.

Additionally, the following instance features can now be customized on a per-platform basis:
* `assign_public_ip`: Whether to assign a public IP to the instance.
* `aws_profile`: The AWS SDK profile to use for the operation (useful if running instances for a single scenario across multiple AWS accounts)
* `boot_wait_seconds`: The time to wait after initial SSH connection before completing the `create` operation.
* `cloud_config`: Cloud Config properties to render into the instance's user-data.
* `region`: The region to create the instance in (useful if running a multi-instance scenario across multiple regions)
* `ssh_port`: The port used to connect to the instance.
* `ssh_user`: The username used to connect to the instance.
* `volumes`: Additional volumes to create and mount on the instance.