### PR TITLE
Improved flexibility for image_filters in create.yml

### DIFF
--- a/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_ec2/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -138,8 +138,9 @@
     - name: Look up EC2 AMI(s) by owner and name (if image not set)
       ec2_ami_info:
         owners: "{{ item.image_owner }}"
-        filters:
-          name: "{{ item.image_name }}"
+        filters: "{{ item.image_filters | default({}) | combine(image_name_map) }}"
+      vars:
+        image_name_map: "{% if item.image_name is defined and item.image_name | length > 0 %}{{ { 'name': item.image_name } }}{% else %}{}{% endif %}"
       loop: "{{ platforms }}"
       loop_control:
         label: "{{ item.name }}"


### PR DESCRIPTION
I sought to specify my AMI via the 'product-code', as shown in the documentation (ahem),
but it failed to work as expected.

This patch fixes that by replacing the explicit 'ec2_ami_info.filters.name' value with all
values in the molecule.yml file's 'platform[*].image_filters' value.

For backwards compatibility a temporary dict is used to hold any existing 'image_name' and
this dict is merged with the 'ec2_ami_info.filters' dictionary. If 'name' is specified in
both dictionaries the one specified as 'image_name' will dominate.

TESTING

I successfully ran full molecule tests with

```
platforms:

  - name: molecule-test
    image_owner: '$UBUNTU_ACCOUNT_ID'
    image_filters:
      'product-code': '$UBUNTU_2204_PRODUCT_CODE'
      'product-code.type': marketplace
    region: us-west-2
    ...
```

where the role's directory contained the .env.yml file values of

```
UBUNTU_ACCOUNT_ID: '679593333241'
UBUNTU_2204_PRODUCT_CODE: '47xbq...'
```

where the product code is from a previously launched instance from this marketplace,
not the marketplace's 'product ID'. (If you use that you get a response saying you
must subscribe to the product.)